### PR TITLE
Fix/optional envs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ secrets/
 *.tfstate.backup
 .terraform.lock.hcl
 .terraform/ 
+
+# Logs
+*.log

--- a/README.md
+++ b/README.md
@@ -40,10 +40,9 @@ A FastAPI-based backend for a tutoring platform that connects students with tuto
 
 5. Inside this environment, navigate to the app folder
 
-6. Create an .env file to declare keys, follow the config.py file for more instructions. When the file is created, make sure it’s in the same directory as the main.py
+6. Optionally, include the environment variables `GITLAB_CLIENT_ID` and `GITLAB_CLIENT_SECRET` for a Gitlab Oauth appliation. This will allow you to access the auth/login and auth/signup endpoints, which use Gitlab as an identity provider.
 
 7. Run main.py in the virtual environment
-
 
 
 ## Endpoint testing
@@ -58,8 +57,8 @@ Endpoint calls:
 
 1. http://localhost:8000/auth/generate-admin-token 
 
-This will return an acess token. This token can then be used as a bearer for the following endpoint. 
+This will return an acess token. This token can then be used as a bearer token in the authorization header of subsequent requests. To verify the token is working as intended, make a GET request to the following endpoint (using the token in the header as described):
 
 2. http://127.0.0.1:8000/auth/secure
 
-Now you have access to secure data.
+This should validate the token and return the data encoded in it.

--- a/tutoring_app/app/config.py
+++ b/tutoring_app/app/config.py
@@ -1,6 +1,8 @@
 from pydantic_settings import BaseSettings, SettingsConfigDict
 from functools import lru_cache
 from typing import Optional
+import base64
+import secrets
 
 class Settings(BaseSettings):
     """
@@ -39,7 +41,7 @@ class Settings(BaseSettings):
     # Token settings
     access_token_expire_minutes: int = 60
     refresh_token_expire_days: int = 7
-    secret_key: Optional[str] = None
+    secret_key: Optional[str] = secrets.token_hex(20)
     hash_algorithm: str = "HS256"
 
     # Logs settings

--- a/tutoring_app/app/config.py
+++ b/tutoring_app/app/config.py
@@ -39,15 +39,15 @@ class Settings(BaseSettings):
     # Token settings
     access_token_expire_minutes: int = 60
     refresh_token_expire_days: int = 7
-    secret_key: str
+    secret_key: Optional[str] = None
     hash_algorithm: str = "HS256"
 
     # Logs settings
     logs_dir: str = "logs"
 
     # Gitlab OAuth settings
-    gitlab_client_id: str
-    gitlab_client_secret: str
+    gitlab_client_id: Optional[str] = None
+    gitlab_client_secret: Optional[str] = None
     gitlab_redirect_uri: str = "http://localhost:8000/auth/callback" 
     gitlab_base_url: str = "https://gitlab.com"
     gitlab_api_url: str = "https://gitlab.com/oauth/userinfo"

--- a/tutoring_app/app/routers/authentication.py
+++ b/tutoring_app/app/routers/authentication.py
@@ -48,32 +48,36 @@ GITLAB_API_URL = get_settings().gitlab_api_url
 oauth = None
 gitlab = None
 
-try:
-    config = Config(environ={
-        "GITLAB_CLIENT_ID": GITLAB_CLIENT_ID,
-        "GITLAB_CLIENT_SECRET": GITLAB_CLIENT_SECRET,
-        "GITLAB_SERVER_METADATA_URL": f"{GITLAB_BASE_URL}/.well-known/openid-configuration",
-        "GITLAB_REDIRECT_URI": GITLAB_REDIRECT_URI,
-    })
-    
-    oauth = OAuth(config)
-    gitlab = oauth.register(
-        name="gitlab",
-        client_id=GITLAB_CLIENT_ID,
-        client_secret=GITLAB_CLIENT_SECRET,
-        server_metadata_url=f"{GITLAB_BASE_URL}/.well-known/openid-configuration",
-        client_kwargs={"scope": "openid profile email read_user"},
-    )
-    logger.info("GitLab OAuth initialized successfully")
-except Exception as e:
-    logger.error(f"Failed to initialize GitLab OAuth: {str(e)}")
-    raise e
+if GITLAB_CLIENT_ID and GITLAB_CLIENT_SECRET:
+    try:
+        config = Config(environ={
+            "GITLAB_CLIENT_ID": GITLAB_CLIENT_ID,
+            "GITLAB_CLIENT_SECRET": GITLAB_CLIENT_SECRET,
+            "GITLAB_SERVER_METADATA_URL": f"{GITLAB_BASE_URL}/.well-known/openid-configuration",
+            "GITLAB_REDIRECT_URI": GITLAB_REDIRECT_URI,
+        })
+        
+        oauth = OAuth(config)
+        gitlab = oauth.register(
+            name="gitlab",
+            client_id=GITLAB_CLIENT_ID,
+            client_secret=GITLAB_CLIENT_SECRET,
+            server_metadata_url=f"{GITLAB_BASE_URL}/.well-known/openid-configuration",
+            client_kwargs={"scope": "openid profile email read_user"},
+        )
+        logger.info("GitLab OAuth initialized successfully")
+    except Exception as e:
+        logger.error(f"Failed to initialize GitLab OAuth: {str(e)}")
+        raise e
 
 # Add these constants
 SECRET_KEY = get_settings().secret_key
 ALGORITHM = get_settings().hash_algorithm
 TOKEN_EXPIRE_MINUTES = get_settings().access_token_expire_minutes 
 REFRESH_TOKEN_EXPIRE_DAYS = get_settings().refresh_token_expire_days
+
+if not SECRET_KEY:
+    SECRET_KEY = os.urandom(32)
 
 # Token store
 # This is a simple in-memory store for demonstration purposes, we should replace this with a database
@@ -254,6 +258,9 @@ async def refresh_token(request: Request, db = Depends(get_db), payload : Decode
 @router.get("/login", response_model=Union[LoggedInResponse, SignUpResponse, None])
 @limiter.limit("10/minute")
 async def login(request: Request, gitlab_token = Depends(get_gitlab_token), db = Depends(get_db)):
+    if not GITLAB_CLIENT_ID or not GITLAB_CLIENT_SECRET:
+        raise HTTPException(status_code=500, detail="GitLab client credentials not set. Cannot use this endpoint.")
+
     """Login endpoint"""
     # Fetch user info using the token with the gitlab object
     if (gitlab_token):
@@ -339,6 +346,10 @@ async def auth_callback(request: Request, db = Depends(get_db)):
 @limiter.limit("10/minute")
 def signup(request : Request, token: str, db = Depends(get_db)):
     """Sign up endpoint. Requires a one time JWT token which is generated after successful authentication - see auth_callback."""
+    
+    if not GITLAB_CLIENT_ID or not GITLAB_CLIENT_SECRET:
+        raise HTTPException(status_code=500, detail="GitLab client credentials not set. Cannot use this endpoint.")
+
     try:
         payload = jwt.decode(token, SECRET_KEY, algorithms=[ALGORITHM])
 

--- a/tutoring_app/app/routers/authentication.py
+++ b/tutoring_app/app/routers/authentication.py
@@ -76,8 +76,6 @@ ALGORITHM = get_settings().hash_algorithm
 TOKEN_EXPIRE_MINUTES = get_settings().access_token_expire_minutes 
 REFRESH_TOKEN_EXPIRE_DAYS = get_settings().refresh_token_expire_days
 
-if not SECRET_KEY:
-    SECRET_KEY = os.urandom(32)
 
 # Token store
 # This is a simple in-memory store for demonstration purposes, we should replace this with a database


### PR DESCRIPTION
Made it so that the environment variables are optionals (GITLAB_CLIENT_ID, GITLAB_CLIENT_SECRET and SECRET_KEY). If the gitlab variables are not set, the login and signup endpoints will not be available. If the SECRET_KEY is not set, then a new one will be generated at runtime.